### PR TITLE
🚨 fix simple compiler warning

### DIFF
--- a/app/app.cpp
+++ b/app/app.cpp
@@ -83,16 +83,16 @@ int main() {
     //    }
     SMTLogicBlock smtLogicBlock(true, std::cout);
     smtLogicBlock.setOutputLogic(SMTLibLogic::QF_UF);
-    LogicTerm     a = smtLogicBlock.makeVariable("a", CType::BOOL);
-    LogicTerm     b = smtLogicBlock.makeVariable("b", CType::BOOL);
-    LogicTerm     c = smtLogicBlock.makeVariable("c", CType::BOOL);
-    LogicTerm     d = smtLogicBlock.makeVariable("d", CType::BOOL);
-    LogicTerm     e = smtLogicBlock.makeVariable("e", CType::BOOL);
-    LogicTerm     f = smtLogicBlock.makeVariable("f", CType::BOOL);
-    LogicTerm     g = smtLogicBlock.makeVariable("g", CType::BOOL);
-    LogicTerm     h = smtLogicBlock.makeVariable("h", CType::BOOL);
-    LogicTerm     i = smtLogicBlock.makeVariable("i", CType::BOOL);
-    LogicTerm     j = smtLogicBlock.makeVariable("j", CType::BOOL);
+    LogicTerm a = smtLogicBlock.makeVariable("a", CType::BOOL);
+    LogicTerm b = smtLogicBlock.makeVariable("b", CType::BOOL);
+    LogicTerm c = smtLogicBlock.makeVariable("c", CType::BOOL);
+    LogicTerm d = smtLogicBlock.makeVariable("d", CType::BOOL);
+    LogicTerm e = smtLogicBlock.makeVariable("e", CType::BOOL);
+    LogicTerm f = smtLogicBlock.makeVariable("f", CType::BOOL);
+    LogicTerm g = smtLogicBlock.makeVariable("g", CType::BOOL);
+    LogicTerm h = smtLogicBlock.makeVariable("h", CType::BOOL);
+    LogicTerm i = smtLogicBlock.makeVariable("i", CType::BOOL);
+    LogicTerm j = smtLogicBlock.makeVariable("j", CType::BOOL);
     smtLogicBlock.assertFormula(a || b);
     smtLogicBlock.assertFormula(c && d);
     LogicTerm ch = c || (a == b);

--- a/include/LogicBlock/SMTLibLogicBlock.hpp
+++ b/include/LogicBlock/SMTLibLogicBlock.hpp
@@ -33,7 +33,7 @@ class SMTLogicBlock: public logicbase::LogicBlock {
 protected:
     std::map<unsigned long long, LogicTerm> constants;
     std::unordered_set<SMTLibLogic>         requiredLogics;
-    SMTLibLogic                            outputLogic;
+    SMTLibLogic                             outputLogic;
     std::ostream&                           out;
     void                                    internal_reset() override;
 
@@ -41,7 +41,7 @@ public:
     explicit SMTLogicBlock(bool convertWhenAssert = false, std::ostream& out = std::cout):
         logicbase::LogicBlock(convertWhenAssert), out(out) {}
 
-    void  assertFormula(const LogicTerm& a) override;
+    void   assertFormula(const LogicTerm& a) override;
     void   produceInstance() override;
     Result solve() override;
     void   reset() override {
@@ -56,7 +56,7 @@ public:
     void addRequiredLogic(SMTLibLogic logic) { requiredLogics.insert(logic); }
 
 private:
-    SMTLibLogic getLogicForTerm(const LogicTerm& a);
+    SMTLibLogic        getLogicForTerm(const LogicTerm& a);
     static SMTLibLogic getMinimumLogic(const SMTLibLogic& a, const SMTLibLogic& b);
 
     void               collectVariables(const LogicTerm& a);
@@ -71,4 +71,3 @@ private:
 };
 
 #endif
-

--- a/include/LogicTerm/Logic.hpp
+++ b/include/LogicTerm/Logic.hpp
@@ -280,7 +280,7 @@ namespace logicbase {
         [[nodiscard]] virtual unsigned long long            getBitVectorValue() const                = 0;
         [[nodiscard]] virtual short                         getBitVectorSize() const                 = 0;
         [[nodiscard]] virtual const std::string&            getName() const                          = 0;
-        [[nodiscard]] virtual std::string             getConstantValue() const = 0;
+        [[nodiscard]] virtual std::string                   getConstantValue() const                 = 0;
         [[nodiscard]] virtual Logic*                        getLogic() const                         = 0;
         [[nodiscard]] virtual std::shared_ptr<TermImpl>     getImplementation() const                = 0;
         [[nodiscard]] virtual bool                          deepEquals(const LogicTerm& other) const = 0;

--- a/include/LogicTerm/LogicTerm.hpp
+++ b/include/LogicTerm/LogicTerm.hpp
@@ -244,7 +244,7 @@ namespace logicbase {
         [[nodiscard]] unsigned long long            getBitVectorValue() const override;
         [[nodiscard]] short                         getBitVectorSize() const override;
         [[nodiscard]] const std::string&            getName() const override;
-        [[nodiscard]] std::string             getConstantValue() const override;
+        [[nodiscard]] std::string                   getConstantValue() const override;
         [[nodiscard]] std::shared_ptr<TermImpl>     getImplementation() const override;
         [[nodiscard]] Logic*                        getLogic() const override;
 

--- a/include/LogicTerm/TermImpl.hpp
+++ b/include/LogicTerm/TermImpl.hpp
@@ -127,5 +127,5 @@ namespace logicbase {
 
         static void reset() { gid = 0; }
     };
-};     // namespace logicbase
+}     // namespace logicbase
 #endif // TermImpl_HPP

--- a/include/LogicTerm/TermImpl.hpp
+++ b/include/LogicTerm/TermImpl.hpp
@@ -127,5 +127,5 @@ namespace logicbase {
 
         static void reset() { gid = 0; }
     };
-}     // namespace logicbase
+} // namespace logicbase
 #endif // TermImpl_HPP


### PR DESCRIPTION
This PR fixes the
```bash
LogicBlocks/include/LogicTerm/TermImpl.hpp:130:2: warning: extra ‘;’ [-Wpedantic]
  130 | };     // namespace logicbase
      |  ^
```
compiler warning.