### PR TITLE
🐛 Fix commander grouping

### DIFF
--- a/src/Encodings/Encodings.cpp
+++ b/src/Encodings/Encodings.cpp
@@ -107,16 +107,15 @@ namespace encodings {
             return vars;
         }
         std::vector<NestedVar> ret{};
-        size_t                 numGr = numVars / maxSize;
+        const std::size_t      numGr = numVars / maxSize;
         ret.reserve(numGr);
-        for (uint32_t i = 0U; i < numGr; i++) {
-            auto from = vars.begin();
-            std::advance(from, static_cast<int64_t>(i * numVars / numGr));
-            auto to = from;
+        auto to = vars.begin();
+        for (std::size_t i = 0U; i < numGr; i++) {
+            const auto from = to;
             if (i == numGr - 1U) {
                 to = vars.end();
             } else {
-                std::advance(to, static_cast<int64_t>(numVars / numGr));
+                std::advance(to, maxSize);
             }
             ret.emplace_back(LogicTerm::noneTerm(), std::vector<NestedVar>(from, to));
         }

--- a/src/Encodings/Encodings.cpp
+++ b/src/Encodings/Encodings.cpp
@@ -95,7 +95,7 @@ namespace encodings {
         for (const auto& var: vars) {
             vVars.emplace_back(var);
         }
-        if (vVars.size() <= 6U) {
+        if (vVars.size() < 6U) {
             return vVars;
         }
         return groupVarsAux(vVars, maxSize);


### PR DESCRIPTION
This PR fixes a rather nasty bug in the commander encoding variable grouping function.
The integer divisions in `i * numVars / numGr` can lead to nasty errors that produce a wrong variable grouping where certain variables are skipped.
This can easily be avoided by refactoring the respective function slightly.

In addition, this PR lowers the limit where the commander encoding is used to `6` following the analysis in the original paper. See https://www.cs.cmu.edu/~wklieber/papers/2007_efficient-cnf-encoding-for-selecting-1.pdf
