### PR TITLE
Fixed bug in `TermImpl::deepEquals`.

### DIFF
--- a/src/LogicTerm/TermImpl.cpp
+++ b/src/LogicTerm/TermImpl.cpp
@@ -248,7 +248,7 @@ bool TermImpl::deepEquals(const TermImpl& other) const {
             return false;
         }
     }
-    return this->getID() == other.getID();
+    return true;
 }
 void TermImpl::prettyPrint(std::ostream& os, int32_t printDepth, bool isNeg, bool printNL, bool lastNL) const {
     if (!isNeg) {


### PR DESCRIPTION
Deep equality check of terms trys to recursively check all subnodes of a Term. But at the end of `deepEquals` it still compares the `ID` of the Terms. I think that will never happen or is at least unintended. If the same Term is generated two times it will never be recognized as equal because of this.