### PR TITLE
Fix bug in dump internal state.

### DIFF
--- a/include/LogicBlock/Z3Logic.hpp
+++ b/include/LogicBlock/Z3Logic.hpp
@@ -78,7 +78,7 @@ namespace z3logic {
         void        dumpZ3State(std::ostream& stream);
         std::string dumpInternalSolver() override {
             std::stringstream ss;
-            ss << solver;
+            ss << (*solver);
             try {
                 ctx->check_error();
             } catch (const z3::exception& e) {
@@ -114,7 +114,7 @@ namespace z3logic {
         bool        minimize(const LogicTerm& term) override;
         std::string dumpInternalSolver() override {
             std::stringstream ss;
-            ss << optimizer;
+            ss << (*optimizer);
             try {
                 ctx->check_error();
             } catch (const z3::exception& e) {


### PR DESCRIPTION
After changing from reference member to pointer there was a bug where the pointer was printed instead of the solver when dumping the internal state of the `Z3LogicOptimizer`.